### PR TITLE
Chore: Add HTTP stub server to behavior tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,12 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.xebialabs.restito</groupId>
+            <artifactId>restito</artifactId>
+            <version>0.9.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/com/github/themasterchef/loadtest4j/drivers/nop/NopTest.java
+++ b/src/test/java/com/github/themasterchef/loadtest4j/drivers/nop/NopTest.java
@@ -8,7 +8,7 @@ import org.junit.experimental.categories.Category;
 @Category(UnitTest.class)
 public class NopTest extends LoadTesterTest {
     @Override
-    public LoadTester sut() {
+    public LoadTester sut(String serviceUrl) {
         return new Nop();
     }
 }

--- a/src/test/java/com/github/themasterchef/loadtest4j/drivers/wrk/WrkTest.java
+++ b/src/test/java/com/github/themasterchef/loadtest4j/drivers/wrk/WrkTest.java
@@ -10,8 +10,8 @@ import java.time.Duration;
 @Category(IntegrationTest.class)
 public class WrkTest extends LoadTesterTest {
     @Override
-    public LoadTester sut() {
+    public LoadTester sut(String serviceUrl) {
         final String executable = "src/test/resources/bin/wrk";
-        return new Wrk(1, Duration.ofSeconds(1), executable, 1, "https://example.com");
+        return new Wrk(1, Duration.ofSeconds(1), executable, 1, serviceUrl);
     }
 }


### PR DESCRIPTION
Implements part of #4 

Improve behavior tests by adding an HTTP stub server. This will let us exercise them locally in the first instance.

Later on we'll get wrk set up in Travis so that we can run these tests all the way through on CI too.